### PR TITLE
fix: Add word break in rant cards

### DIFF
--- a/pages/rants/index.tsx
+++ b/pages/rants/index.tsx
@@ -92,7 +92,7 @@ export default function Reviews({ }: {}) {
                             !isLoading ?
                                 rants
                                     .map((rant) => (
-                                        <div className="card shadow-lg bg-base-100 text-base-content mt-5" key={rant.created_at}>
+                                        <div className="card shadow-lg bg-base-100 break-words text-base-content mt-5" key={rant.created_at}>
                                             <div className="card-body">
                                                 <div className="badge badge-outline my-3 px-3">Rant #{rant.id} | {rant.public == 1 ? "Public" : "Private"}</div>
                                                 <p>{rant.rant}</p>


### PR DESCRIPTION
## Description

Fixes an issue where if a rant has a really long word, it doesn't overflow the card and instead wraps around


## Type of change

Bug fix (non-breaking change which fixes an issue)

## Screenshots
### Before
<img src="https://github.com/user-attachments/assets/cf5e9d9c-84bd-4359-87f6-b84d4227706b" width="50%" />

### After
<img src="https://github.com/user-attachments/assets/452aef55-7f99-47fd-80c9-1db971cba38e" width="50%" />


## Checklist:

- [x] I used `pnpm` for my project dependencies
- [x] I didnt push any `.env` files
