### PR TITLE
fix: Center the home page text

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -114,7 +114,7 @@ export default function Home() {
         <div className="container mx-auto px-4 flex flex-col md:flex-row items-center justify-between">
           <div className="md:w-1/2 mb-8 md:mb-0">
             <h1 className="text-5xl md:text-6xl font-bold mb-4 text-center">Handouts4U.</h1>
-            <p className="text-md md:text-xl text-white mb-6">Your complete resource hub for BITS Pilani.</p>
+            <p className="text-md md:text-xl text-white mb-6 text-center">Your complete resource hub for BITS Pilani.</p>
 
             {/* Main Buttons */}
             <div className="grid md:grid-cols-3 justify-around" >


### PR DESCRIPTION
## Description

<pre>
Center text.
</pre>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New website feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New script (new python script for handouts handling)
- [ ] New resource (new file that is added)
  - [ ] Adding new / updating notes
  - [ ] Adding new / updating handouts
  - [ ] Adding new / updating chronicles
  - [ ] Adding new / updating reviews
- [ ] Misc (explain in description)

## Checklist:

- [x] I used `pnpm` for my project dependencies
- [x] I didnt push any `.env` files
